### PR TITLE
chore: 필요없는 .npmrc 설정 제거

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,1 +1,0 @@
-legacy-peer-deps=true


### PR DESCRIPTION
## Pull Request 설명
storybook을 사용하지 않으므로 legacy-peer-deps 설정도 제거
