### PR TITLE
fix : status code 반영이 안되는 문제 해결

### DIFF
--- a/backend/demo/src/main/java/com/snacks/demo/controller/AuthController.java
+++ b/backend/demo/src/main/java/com/snacks/demo/controller/AuthController.java
@@ -29,7 +29,7 @@ public class AuthController {
   @PostMapping(" ")
   public ResponseEntity signUp(@Validated @RequestBody UserDto userDto, BindingResult bindingResult) {
     if (bindingResult.hasErrors()) {
-      return ResponseEntity.badRequest().body(responseService.errorResponse(400, bindingResult.getFieldError().getDefaultMessage()));
+      return ResponseEntity.badRequest().body(responseService.errorResponse(bindingResult.getFieldError().getDefaultMessage()));
     }
     return authService.signUp(userDto);
   }

--- a/backend/demo/src/main/java/com/snacks/demo/controller/AuthController.java
+++ b/backend/demo/src/main/java/com/snacks/demo/controller/AuthController.java
@@ -1,10 +1,10 @@
 package com.snacks.demo.controller;
 
 import com.snacks.demo.dto.UserDto;
-import com.snacks.demo.response.CommonResponse;
 import com.snacks.demo.response.ResponseService;
 import com.snacks.demo.service.AuthService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
@@ -27,9 +27,9 @@ public class AuthController {
   PasswordEncoder passwordEncoder;
 
   @PostMapping(" ")
-  public CommonResponse signUp(@Validated @RequestBody UserDto userDto, BindingResult bindingResult) {
+  public ResponseEntity signUp(@Validated @RequestBody UserDto userDto, BindingResult bindingResult) {
     if (bindingResult.hasErrors()) {
-      return responseService.errorResponse(400, bindingResult.getFieldError().getDefaultMessage());
+      return ResponseEntity.badRequest().body(responseService.errorResponse(400, bindingResult.getFieldError().getDefaultMessage()));
     }
     return authService.signUp(userDto);
   }

--- a/backend/demo/src/main/java/com/snacks/demo/dto/UserDto.java
+++ b/backend/demo/src/main/java/com/snacks/demo/dto/UserDto.java
@@ -1,5 +1,6 @@
 package com.snacks.demo.dto;
 
+import com.snacks.demo.response.ResponseMessage;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
@@ -12,10 +13,10 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UserDto {
-  @NotBlank(message = "이메일은 필수 입력 값입니다.")
-  @Email(message = "올바른 이메일 형식이 아닙니다.")
+  @NotBlank(message = ResponseMessage.EMAIL_NULL)
+  @Email(message = ResponseMessage.EMAIL_FORMAT_ERROR)
   private String email;
 
-  @NotBlank(message = "비밀번호 값은 필수 입력 값입니다.")
+  @NotBlank(message = ResponseMessage.PASSWORD_NULL)
   private String password;
 }

--- a/backend/demo/src/main/java/com/snacks/demo/response/CommonResponse.java
+++ b/backend/demo/src/main/java/com/snacks/demo/response/CommonResponse.java
@@ -1,7 +1,6 @@
 package com.snacks.demo.response;
 
 public class CommonResponse {
-    public int status;
     public String log;
 }
 

--- a/backend/demo/src/main/java/com/snacks/demo/response/ResponseMessage.java
+++ b/backend/demo/src/main/java/com/snacks/demo/response/ResponseMessage.java
@@ -1,0 +1,9 @@
+package com.snacks.demo.response;
+
+public record ResponseMessage() {
+  public static final String EMAIL_EXSIST = "이미 존재하는 이메일입니다.";
+  public static final String EMAIL_NULL = "이메일은 필수 입력 값입니다.";
+  public static final String EMAIL_FORMAT_ERROR = "올바른 이메일 형식이 아닙니다.";
+  public static final String PASSWORD_NULL = "비밀번호 값은 필수 입력 값입니다.";
+
+}

--- a/backend/demo/src/main/java/com/snacks/demo/response/ResponseService.java
+++ b/backend/demo/src/main/java/com/snacks/demo/response/ResponseService.java
@@ -42,8 +42,8 @@ public class ResponseService {
         return (errorResponse);
     }
     //CommonResponse의 값을 성공으로 변환
-    void setSuccessResponse(CommonResponse response, int stauts) {
-        response.status = stauts;
+    void setSuccessResponse(CommonResponse response, int status) {
+        response.status = status;
         response.log = "OK";
     }
 }

--- a/backend/demo/src/main/java/com/snacks/demo/response/ResponseService.java
+++ b/backend/demo/src/main/java/com/snacks/demo/response/ResponseService.java
@@ -7,28 +7,28 @@ import java.util.List;
 @Service
 public class ResponseService {
     //반환할 데이터가 없을 때
-    public CommonResponse getCommonResponse() {
+    public CommonResponse getCommonResponse(int status) {
         CommonResponse commonResponse = new CommonResponse();
-        setSuccessResponse(commonResponse);
+        setSuccessResponse(commonResponse, status);
 
         return (commonResponse);
     }
 
     //반환할 데이터가 1개 일 떄
-    public<T> SingleResponse<T> getSingleResponse(T data) {
+    public<T> SingleResponse<T> getSingleResponse(T data, int status) {
         SingleResponse singleResponse = new SingleResponse();
         singleResponse.data = data;
-        setSuccessResponse(singleResponse);
+        setSuccessResponse(singleResponse, status);
 
 
         return (singleResponse);
     }
 
     //반환할 데이터가 여러개 일 때
-    public<T> ListResponse<T> getListResponse(T datalist) {
+    public<T> ListResponse<T> getListResponse(T datalist, int status) {
         ListResponse<T> listResponse = new ListResponse();
         listResponse.dataList = datalist;
-        setSuccessResponse(listResponse);
+        setSuccessResponse(listResponse, status);
         return (listResponse);
     }
 
@@ -42,8 +42,8 @@ public class ResponseService {
         return (errorResponse);
     }
     //CommonResponse의 값을 성공으로 변환
-    void setSuccessResponse(CommonResponse response) {
-        response.status = 200;
+    void setSuccessResponse(CommonResponse response, int stauts) {
+        response.status = stauts;
         response.log = "OK";
     }
 }

--- a/backend/demo/src/main/java/com/snacks/demo/response/ResponseService.java
+++ b/backend/demo/src/main/java/com/snacks/demo/response/ResponseService.java
@@ -7,43 +7,41 @@ import java.util.List;
 @Service
 public class ResponseService {
     //반환할 데이터가 없을 때
-    public CommonResponse getCommonResponse(int status) {
+    public CommonResponse getCommonResponse() {
         CommonResponse commonResponse = new CommonResponse();
-        setSuccessResponse(commonResponse, status);
+        setSuccessResponse(commonResponse);
 
         return (commonResponse);
     }
 
     //반환할 데이터가 1개 일 떄
-    public<T> SingleResponse<T> getSingleResponse(T data, int status) {
+    public<T> SingleResponse<T> getSingleResponse(T data) {
         SingleResponse singleResponse = new SingleResponse();
         singleResponse.data = data;
-        setSuccessResponse(singleResponse, status);
+        setSuccessResponse(singleResponse);
 
 
         return (singleResponse);
     }
 
     //반환할 데이터가 여러개 일 때
-    public<T> ListResponse<T> getListResponse(T datalist, int status) {
+    public<T> ListResponse<T> getListResponse(T datalist) {
         ListResponse<T> listResponse = new ListResponse();
         listResponse.dataList = datalist;
-        setSuccessResponse(listResponse, status);
+        setSuccessResponse(listResponse);
         return (listResponse);
     }
 
     //오류를 반환할때
-    public CommonResponse errorResponse(int status, String log)
+    public CommonResponse errorResponse(String log)
     {
         CommonResponse errorResponse = new CommonResponse();
-        errorResponse.status = status;
         errorResponse.log = log;
 
         return (errorResponse);
     }
     //CommonResponse의 값을 성공으로 변환
-    void setSuccessResponse(CommonResponse response, int status) {
-        response.status = status;
+    void setSuccessResponse(CommonResponse response) {
         response.log = "OK";
     }
 }

--- a/backend/demo/src/main/java/com/snacks/demo/service/AuthService.java
+++ b/backend/demo/src/main/java/com/snacks/demo/service/AuthService.java
@@ -7,6 +7,7 @@ import com.snacks.demo.response.CommonResponse;
 import com.snacks.demo.response.ResponseService;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -35,9 +36,9 @@ public class AuthService {
     Optional<User> existedUser = authRepository.findByEmail(user.getEmail());
 
     if(existedUser.isPresent()){
-      return ResponseEntity.status(409).body(responseService.errorResponse(409,"이미 존재하는 이메일입니다."));
+      return ResponseEntity.status(HttpStatus.CONFLICT).body(responseService.errorResponse(409,"이미 존재하는 이메일입니다."));
     }
     authRepository.save(user);
-    return ResponseEntity.status(201).body(responseService.getCommonResponse(201));
+    return ResponseEntity.status(HttpStatus.CREATED).body(responseService.getCommonResponse(201));
   }
 }

--- a/backend/demo/src/main/java/com/snacks/demo/service/AuthService.java
+++ b/backend/demo/src/main/java/com/snacks/demo/service/AuthService.java
@@ -36,9 +36,9 @@ public class AuthService {
     Optional<User> existedUser = authRepository.findByEmail(user.getEmail());
 
     if(existedUser.isPresent()){
-      return ResponseEntity.status(HttpStatus.CONFLICT).body(responseService.errorResponse(409,"이미 존재하는 이메일입니다."));
+      return ResponseEntity.status(HttpStatus.CONFLICT).body(responseService.errorResponse("이미 존재하는 이메일입니다."));
     }
     authRepository.save(user);
-    return ResponseEntity.status(HttpStatus.CREATED).body(responseService.getCommonResponse(201));
+    return ResponseEntity.status(HttpStatus.CREATED).body(responseService.getCommonResponse());
   }
 }

--- a/backend/demo/src/main/java/com/snacks/demo/service/AuthService.java
+++ b/backend/demo/src/main/java/com/snacks/demo/service/AuthService.java
@@ -7,6 +7,7 @@ import com.snacks.demo.response.CommonResponse;
 import com.snacks.demo.response.ResponseService;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -25,7 +26,7 @@ public class AuthService {
   }
 
 
-  public CommonResponse signUp(UserDto userDto){
+  public ResponseEntity signUp(UserDto userDto){
     //signup
     User user = new User();
     user.setEmail(userDto.getEmail());
@@ -34,9 +35,9 @@ public class AuthService {
     Optional<User> existedUser = authRepository.findByEmail(user.getEmail());
 
     if(existedUser.isPresent()){
-      return responseService.errorResponse(409, "이미 존재하는 이메일입니다.");
+      return ResponseEntity.status(409).body(responseService.errorResponse(409,"이미 존재하는 이메일입니다."));
     }
     authRepository.save(user);
-    return responseService.getCommonResponse();
+    return ResponseEntity.status(201).body(responseService.getCommonResponse(201));
   }
 }

--- a/backend/demo/src/main/java/com/snacks/demo/service/AuthService.java
+++ b/backend/demo/src/main/java/com/snacks/demo/service/AuthService.java
@@ -4,6 +4,7 @@ import com.snacks.demo.dto.UserDto;
 import com.snacks.demo.entity.User;
 import com.snacks.demo.repository.AuthRepository;
 import com.snacks.demo.response.CommonResponse;
+import com.snacks.demo.response.ResponseMessage;
 import com.snacks.demo.response.ResponseService;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,7 +37,7 @@ public class AuthService {
     Optional<User> existedUser = authRepository.findByEmail(user.getEmail());
 
     if(existedUser.isPresent()){
-      return ResponseEntity.status(HttpStatus.CONFLICT).body(responseService.errorResponse("이미 존재하는 이메일입니다."));
+      return ResponseEntity.status(HttpStatus.CONFLICT).body(responseService.errorResponse(ResponseMessage.EMAIL_EXSIST));
     }
     authRepository.save(user);
     return ResponseEntity.status(HttpStatus.CREATED).body(responseService.getCommonResponse());

--- a/backend/demo/src/test/java/com/snacks/demo/Auth/SignUpTest.java
+++ b/backend/demo/src/test/java/com/snacks/demo/Auth/SignUpTest.java
@@ -21,7 +21,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -112,13 +114,13 @@ public class SignUpTest {
     UserDto userDto = new UserDto(email, password);
 
     //when
-
+    ResponseEntity responseEntity = authService.signUp(userDto);
     //then
     if (expected == true) {
-      assertThat(authService.signUp(userDto).status).isEqualTo(200);
+      assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     }
     else {
-      assertThat(authService.signUp(userDto).status).isEqualTo(409);
+      assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
     }
   }
 
@@ -139,7 +141,7 @@ public class SignUpTest {
         .content(user);
 
     mockMvc.perform(requestBuilder)
-        .andExpect(MockMvcResultMatchers.status().isOk())
+        .andExpect(MockMvcResultMatchers.status().isCreated())
         .andDo(MockMvcResultHandlers.print())
         .andReturn()
         .getResponse();


### PR DESCRIPTION
## Pull Request 설명
<img width="946" alt="이전 응답 코드" src="https://user-images.githubusercontent.com/57864944/202359930-037873d7-5ef4-49bd-a854-6872ae489708.png">

- body의 status 값은 400이지만, 우측 상단의 실제 status code값은 200인 현상 발생

  - ResponseEntity을 적용하여 status code값이 잘 반영되도록 수정
<img width="782" alt="변경 응답 코드" src="https://user-images.githubusercontent.com/57864944/202360238-31899de5-1040-4daf-b9a6-99cadda15afd.png">


- 정상적인 응답시 status code가 무조건 200인 현상 발생

  - CommonResponse에 원하는 status 값을 넣을 수 있도록 수정

- ReponseBody의 status 값 삭제

- record를 사용하여 ResponseBody의 log 상수화

- Test code 수정



## Test 방법
backend/demo/src/test/java/com.snacks.demo/Auth/SignUpTest  실행
