### PR TITLE
feat: 빈공간,swap이동구현

### DIFF
--- a/frontend/src/Dummy.tsx
+++ b/frontend/src/Dummy.tsx
@@ -1,27 +1,18 @@
-import { layoutType } from 'common'
+import { Widgets } from 'common'
 
-export const layoutDummy: layoutType = [
+export const layoutDummy: Widgets = [
   {
-    uuid: '1',
+    uuid: 'weather01',
     name: 'weather',
-    x: 0,
-    y: 0,
-    w: 1,
-    h: 1,
+    x: 2,
+    y: 1,
+    w: 2,
+    h: 2,
     data: JSON.parse('{"aa" : "bb"}'),
   },
   {
-    uuid: '2',
+    uuid: 'memo02',
     name: 'memo',
-    x: 1,
-    y: 0,
-    w: 1,
-    h: 1,
-    data: JSON.parse('{"aa" : "bb"}'),
-  },
-  {
-    uuid: '3',
-    name: 'weather',
     x: 2,
     y: 0,
     w: 1,
@@ -29,8 +20,8 @@ export const layoutDummy: layoutType = [
     data: JSON.parse('{"aa" : "bb"}'),
   },
   {
-    uuid: '4',
-    name: 'ascii',
+    uuid: 'weather03',
+    name: 'weather',
     x: 3,
     y: 0,
     w: 1,
@@ -38,28 +29,37 @@ export const layoutDummy: layoutType = [
     data: JSON.parse('{"aa" : "bb"}'),
   },
   {
-    uuid: '5',
+    uuid: 'ascii04',
+    name: 'ascii',
+    x: 4,
+    y: 1,
+    w: 1,
+    h: 1,
+    data: JSON.parse('{"aa" : "bb"}'),
+  },
+  {
+    uuid: 'todo05',
     name: 'todo',
     x: 4,
-    y: 3,
+    y: 2,
     w: 1,
     h: 1,
     data: JSON.parse('{"aa" : "bb"}'),
   },
   {
-    uuid: '6',
+    uuid: 'memo06',
     name: 'memo',
     x: 0,
-    y: 1,
+    y: 2,
     w: 1,
     h: 1,
     data: JSON.parse('{"aa" : "bb"}'),
   },
   {
-    uuid: '7',
+    uuid: 'timer07',
     name: 'timer',
     x: 1,
-    y: 1,
+    y: 2,
     w: 1,
     h: 1,
     data: JSON.parse('{"aa" : "bb"}'),
@@ -67,7 +67,7 @@ export const layoutDummy: layoutType = [
 ]
 
 export const widgetDummy = {
-  uuid: '1',
+  uuid: 'weather01',
   name: 'weather',
   x: 0,
   y: 0,

--- a/frontend/src/Dummy.tsx
+++ b/frontend/src/Dummy.tsx
@@ -41,7 +41,7 @@ export const layoutDummy: layoutType = [
     uuid: '5',
     name: 'todo',
     x: 4,
-    y: 0,
+    y: 3,
     w: 1,
     h: 1,
     data: JSON.parse('{"aa" : "bb"}'),

--- a/frontend/src/common.d.ts
+++ b/frontend/src/common.d.ts
@@ -6,7 +6,7 @@ export interface Credential {
   password: string
 }
 
-export interface widgetType {
+export interface WidgetType {
   uuid: string
   name: string
   x: number
@@ -15,4 +15,4 @@ export interface widgetType {
   h: number
   data: JSON
 }
-export type layoutType = widgetType[]
+export type Widgets = WidgetType[]

--- a/frontend/src/components/users/Grid.tsx
+++ b/frontend/src/components/users/Grid.tsx
@@ -20,14 +20,14 @@ export const Grid = ({ widgets }: { widgets: Widgets }) => {
     gridTemplateColumns: 'repeat(5, 1fr)',
     gridGap: 10,
   }
-  //state cursorPosition을 기반으로 위젯을 이동한다
+  //state cursorPosition을 기반으로 위젯을 이동한다 [완료][핸들러]
   const handleDragEnd = (event: DragEndEvent) => {
     if (cursorPosition.x !== 0 || cursorPosition.y !== 0) {
       const index = widgets.findIndex(item => item.uuid === event.active.id)
       moveItem(index)
     }
   }
-  //드래그 중의 포인터 움직임을 State에 저장한다
+  //드래그 중의 포인터 움직임을 State에 저장한다 [완료][핸들러]
   const handleDragMove = (event: DragMoveEvent) => {
     if (gridRef.current) {
       setCursorPosition({
@@ -39,16 +39,8 @@ export const Grid = ({ widgets }: { widgets: Widgets }) => {
     //이걸 그리드 사이즈에 대한 비율로 나눠서 어느 정도 이동했는지 좌표를 구한다
     //x, y좌표를 state로 저장한다
   }
-  //위젯 둘을 서로 교환한다.
-  const swapItem = (layout: Widgets, oldIndex: number, newIndex: number) => {
-    const tmpX = layout[oldIndex].x
-    const tmpY = layout[oldIndex].y
-    layout[oldIndex].x = layout[newIndex].x
-    layout[oldIndex].y = layout[newIndex].y
-    layout[newIndex].x = tmpX
-    layout[newIndex].y = tmpY
-  }
-  //해당 위젯이 차지하고 있는 좌표 배열을 반환
+
+  //해당 위젯이 차지하고 있는 좌표 배열을 반환 [완료][tools]
   const makeWidgetCoordinates = (index: number) => {
     const coordList: Coordinate[] = []
     for (let i = 0; i < widgets[index].h; i++) {
@@ -61,11 +53,7 @@ export const Grid = ({ widgets }: { widgets: Widgets }) => {
     }
     return coordList
   }
-  //위젯을 옮길 경우 차지하게 될 좌표 배열을 반환
-  const makeMoveCoordinates = (index: number, coord: Coordinate) => {
-    //const movedWidget = widgets[index]의 깊은 복사
-  }
-  //해당 좌표 범위 내에 존재하고 있는 위젯들의 배열을 반환
+  //해당 좌표 범위 내에 존재하고 있는 위젯들의 배열을 반환 [완료][tools]
   const coordinateRangeWidgets = (start: Coordinate, end: Coordinate) => {
     const widgetList: Widgets = []
     const permutation: Coordinate[] = []
@@ -85,135 +73,7 @@ export const Grid = ({ widgets }: { widgets: Widgets }) => {
     })
     return widgetList
   }
-
-  //위젯을 미는 동작을 수행한다
-  const pushItem = (layout: Widgets, oldIndex: number, newIndex: number) => {
-    const swapCoordinates = makeCoordinates(layout, oldIndex, newIndex)
-    layout.map((ele, index) => {
-      if (index !== oldIndex) {
-        const eleCoordinates = makeCoordinates(layout, index, index)
-        //filtered는 중복된 좌표값 좌표값만 토대로 어떤 위젯인지 찾아야함
-        //각 위젯의 좌표배열을 생성. 배열 중 filteredEle가 있는 지 찾기.
-        const filtered = eleCoordinates.map(it => {
-          return swapCoordinates.filter(swapEle => {
-            return swapEle.x === it.x && swapEle.y === it.y
-          })
-        })
-        if (filtered[0].length === 0) return
-        //filtered 위치만 알지 무슨 위젯인지는 아직 모름
-        //일단 layout을 돌면서 해당 위치를 차지하고 있는 위젯을 찾기
-        filtered[0].map(filteredEle => {
-          const overlapWidget: WidgetType | undefined = layout.find(
-            (layoutEle, index) => {
-              const tmpWidgetCoordinate = makeCoordinates(layout, index, index)
-              const includeWidget = tmpWidgetCoordinate.map(ele => {
-                return ele.x === filteredEle.x && ele.y === filteredEle.y
-              })
-              if (includeWidget.includes(true)) return layoutEle
-            }
-          )
-          if (overlapWidget === undefined) return
-          //overlapWidget까지는 잘 찾아졌음
-          console.log(overlapWidget)
-          if (tryPush(layout, overlapWidget, { x: -1, y: 0 }) === true) return
-          if (tryPush(layout, overlapWidget, { x: 1, y: 0 }) === true) return
-          if (tryPush(layout, overlapWidget, { x: 0, y: 1 }) === true) return
-          if (tryPush(layout, overlapWidget, { x: 0, y: -1 }) === true) return
-          // console.log('밀 수 없음')
-          //위젯을 찾았으면 좌, 우, 상, 하 순서로 밀기 시도. 못찾았다면 밀지 않고 종료
-          //다 실패 시 console.log(밀 수 없음)//
-        })
-        //filtered가 비어있지 않다면 이 ele는 겹치는 위젯이다
-        //겹치는 위젯은 상하좌우로 밀 수 있음.
-        //좌->우->상->하 순서로 검사해서 밀 수 있는 지 확인하고,
-        //가능하다면 밀기
-      }
-    })
-  }
-
-  const tryPush = (
-    layout: Widgets,
-    widget: WidgetType,
-    direction: Coordinate
-  ) => {
-    //layout에서 widget을 찾아서 왼쪽으로 한 칸 밀기
-    //layout 좌표들에서 왼쪽 한 칸 기준으로 비어있는지를 확인하기.
-    const widgetIndex = layout.findIndex(ele => {
-      return ele.uuid === widget.uuid
-    })
-    const widgetCoordinate = makeCoordinates(layout, widgetIndex, widgetIndex)
-    //widgetCoodinate의 좌표들에 (-1, 0)씩 연산해서 이 위치랑 eleCoodinate랑 겹치는지 확인.
-    const moveCoordinate = widgetCoordinate.map(ele => {
-      return { x: ele.x + direction.x, y: ele.y + direction.y }
-    })
-    //오버랩을 한 칸 옮긴 위치랑 비교해서 겹치면 움직이지 말고
-    const tmp = layout.map((ele, index) => {
-      const eleCoordinate = makeCoordinates(layout, index, index)
-      const isOverlap = moveCoordinate.map(moveEle => {
-        return eleCoordinate.map(eleEle => {
-          if (moveEle.x === eleEle.x && moveEle.y === eleEle.y) return false
-          else if (moveEle.x < 0 || moveEle.y) return false
-          else return true
-        })
-      })
-      if (isOverlap[0].includes(false)) return false
-      else {
-        return true
-      }
-    })
-    if (tmp.includes(true)) {
-      //옮길 수 있음
-      widget.x += direction.x
-      widget.y += direction.y
-      return true
-    } else return false
-  }
-
-  // const moveItem = (layout: Widgets, oldIndex: number, newIndex: number) => {
-  //   //push를 먼저 시도하고 실패하면 swap을 시도할 예정 아직 덜만듦
-
-  //   //1. 해당 위젯 스왑될 위치를 다음과 같은 배열로 만듬 [{x, y}, ...] 차지하고 있는 좌표들의 배열
-  //   //2. 위젯리스트를 돌면서 그 위젯에 대한 배열을 만들고, 1의 배열과 비교해서 겹치는 좌표가 있는 지 확인
-  //   //3. 겹치는 좌표가 없다면 바로 스왑
-  //   //4. 겹치는 좌표가 있다면, 그 위젯을 상하좌우로 밀어내기(밀어낼 위치를 검사해 가능 불가능 확인 후 밀기)
-  //   //5. 우선순위는 밀어내기 -> 스왑 -> 불가능
-  //   //드래그 시 CSS 등 세세한 동작은 추후 만들기..
-
-  //   pushItem(layout, oldIndex, newIndex)
-  //   // swapItem(layout, oldIndex, newIndex)
-  // }
-  const moveItemEmpty = (widget: WidgetType) => {
-    const movedWidget: WidgetType = JSON.parse(JSON.stringify(widget))
-    movedWidget.x += cursorPosition.x
-    movedWidget.y += cursorPosition.y
-    const movedRangeWidgets = coordinateRangeWidgets(
-      { x: movedWidget.x, y: movedWidget.y },
-      { x: movedWidget.x + movedWidget.w, y: movedWidget.y + movedWidget.h }
-    ).filter(ele => ele.uuid !== widget.uuid)
-
-    if (
-      movedRangeWidgets.length === 0 &&
-      movedWidget.x >= 0 &&
-      movedWidget.y >= 0 &&
-      movedWidget.x < 5 &&
-      movedWidget.y < 3
-    ) {
-      widget.x += cursorPosition.x
-      widget.y += cursorPosition.y
-      return true
-    }
-    return false //빈공간으로 이동 할 수 없음
-  }
-  const moveItem = (index: number) => {
-    //빈 공간인가? 위젯 크기만큼의 좌표들이 다 비어있어야 함.
-    if (moveItemEmpty(widgets[index]) === true) return
-    //push 가능?
-
-    //swap 가능
-
-    //불가능
-  }
-  //위젯들을 기반으로 위젯이 채워진 좌표계를 만듦
+  //위젯들을 기반으로 위젯이 채워진 좌표계를 만듦 [완료][tools]
   const makeGridCoordinates = () => {
     const newGridCoordinates: Array<{ uuid: string }[]> = new Array(5)
     for (let i = 0; i < 5; i++) {
@@ -227,6 +87,149 @@ export const Grid = ({ widgets }: { widgets: Widgets }) => {
       })
     })
     return newGridCoordinates
+  }
+  //위젯을 옮길 경우 차지하게 될 좌표 배열을 반환 [tools]
+  const makeMoveCoordinates = (index: number, coord: Coordinate) => {}
+
+  //위젯을 미는 동작을 수행한다 [새로 만들 예정][주기능]
+  // const pushItem = (layout: Widgets, oldIndex: number, newIndex: number) => {
+  //   const swapCoordinates = makeCoordinates(layout, oldIndex, newIndex)
+  //   layout.map((ele, index) => {
+  //     if (index !== oldIndex) {
+  //       const eleCoordinates = makeCoordinates(layout, index, index)
+  //       //filtered는 중복된 좌표값 좌표값만 토대로 어떤 위젯인지 찾아야함
+  //       //각 위젯의 좌표배열을 생성. 배열 중 filteredEle가 있는 지 찾기.
+  //       const filtered = eleCoordinates.map(it => {
+  //         return swapCoordinates.filter(swapEle => {
+  //           return swapEle.x === it.x && swapEle.y === it.y
+  //         })
+  //       })
+  //       if (filtered[0].length === 0) return
+  //       //filtered 위치만 알지 무슨 위젯인지는 아직 모름
+  //       //일단 layout을 돌면서 해당 위치를 차지하고 있는 위젯을 찾기
+  //       filtered[0].map(filteredEle => {
+  //         const overlapWidget: WidgetType | undefined = layout.find(
+  //           (layoutEle, index) => {
+  //             const tmpWidgetCoordinate = makeCoordinates(layout, index, index)
+  //             const includeWidget = tmpWidgetCoordinate.map(ele => {
+  //               return ele.x === filteredEle.x && ele.y === filteredEle.y
+  //             })
+  //             if (includeWidget.includes(true)) return layoutEle
+  //           }
+  //         )
+  //         if (overlapWidget === undefined) return
+  //         //overlapWidget까지는 잘 찾아졌음
+  //         if (tryPush(layout, overlapWidget, { x: -1, y: 0 }) === true) return
+  //         if (tryPush(layout, overlapWidget, { x: 1, y: 0 }) === true) return
+  //         if (tryPush(layout, overlapWidget, { x: 0, y: 1 }) === true) return
+  //         if (tryPush(layout, overlapWidget, { x: 0, y: -1 }) === true) return
+  //         //위젯을 찾았으면 좌, 우, 상, 하 순서로 밀기 시도. 못찾았다면 밀지 않고 종료
+  //       })
+  //       //filtered가 비어있지 않다면 이 ele는 겹치는 위젯이다
+  //       //겹치는 위젯은 상하좌우로 밀 수 있음.
+  //       //좌->우->상->하 순서로 검사해서 밀 수 있는 지 확인하고,
+  //       //가능하다면 밀기
+  //     }
+  //   })
+  // }
+  //매개변수로 받은 방향으로 push한다 [새로 만들 예정][주기능]
+  // const tryPush = (
+  //   layout: Widgets,
+  //   widget: WidgetType,
+  //   direction: Coordinate
+  // ) => {
+  //   //layout에서 widget을 찾아서 왼쪽으로 한 칸 밀기
+  //   //layout 좌표들에서 왼쪽 한 칸 기준으로 비어있는지를 확인하기.
+  //   const widgetIndex = layout.findIndex(ele => {
+  //     return ele.uuid === widget.uuid
+  //   })
+  //   const widgetCoordinate = makeCoordinates(layout, widgetIndex, widgetIndex)
+  //   //widgetCoodinate의 좌표들에 (-1, 0)씩 연산해서 이 위치랑 eleCoodinate랑 겹치는지 확인.
+  //   const moveCoordinate = widgetCoordinate.map(ele => {
+  //     return { x: ele.x + direction.x, y: ele.y + direction.y }
+  //   })
+  //   //오버랩을 한 칸 옮긴 위치랑 비교해서 겹치면 움직이지 말고
+  //   const tmp = layout.map((ele, index) => {
+  //     const eleCoordinate = makeCoordinates(layout, index, index)
+  //     const isOverlap = moveCoordinate.map(moveEle => {
+  //       return eleCoordinate.map(eleEle => {
+  //         if (moveEle.x === eleEle.x && moveEle.y === eleEle.y) return false
+  //         else if (moveEle.x < 0 || moveEle.y) return false
+  //         else return true
+  //       })
+  //     })
+  //     if (isOverlap[0].includes(false)) return false
+  //     else {
+  //       return true
+  //     }
+  //   })
+  //   if (tmp.includes(true)) {
+  //     //옮길 수 있음
+  //     widget.x += direction.x
+  //     widget.y += direction.y
+  //     return true
+  //   } else return false
+  // }
+  //위젯 둘을 서로 교환한다. [완료][주기능]
+  const moveItemSwap = (widget: WidgetType) => {
+    //1. cursorPosition를 통해 교환할 위젯을 찾는다. 이동하려는 좌표에 위치하고, w h 크기가 같아야 함.
+    //2. 조건이 맞으면 교환 후 true, 실패하면 false
+    const swapRange = coordinateRangeWidgets(
+      {
+        x: widget.x + cursorPosition.x,
+        y: widget.y + cursorPosition.y,
+      },
+      {
+        x: widget.x + widget.w + cursorPosition.x,
+        y: widget.y + widget.h + cursorPosition.y,
+      }
+    ).filter(ele => ele.uuid !== widget.uuid)
+    if (
+      swapRange.length === 1 &&
+      swapRange[0].w === widget.w &&
+      swapRange[0].h === widget.h
+    ) {
+      const swapWidget = widgets.find(ele => {
+        return ele.uuid === swapRange[0].uuid
+      })
+      if (!swapWidget) return false
+      const swapCoords: Coordinate = { x: swapWidget.x, y: swapWidget.y }
+      swapWidget.x = widget.x
+      swapWidget.y = widget.y
+      widget.x = swapCoords.x
+      widget.y = swapCoords.y
+      return true
+    }
+    return false
+  }
+  //빈 곳으로 위젯을 이동한다 [완료] [주기능]
+  const moveItemEmpty = (widget: WidgetType) => {
+    const movedWidget: WidgetType = JSON.parse(JSON.stringify(widget))
+    movedWidget.x += cursorPosition.x
+    movedWidget.y += cursorPosition.y
+    const movedRangeWidgets = coordinateRangeWidgets(
+      { x: movedWidget.x, y: movedWidget.y },
+      { x: movedWidget.x + movedWidget.w, y: movedWidget.y + movedWidget.h }
+    ).filter(ele => ele.uuid !== widget.uuid)
+    if (
+      movedRangeWidgets.length === 0 &&
+      movedWidget.x >= 0 &&
+      movedWidget.y >= 0 &&
+      movedWidget.x < 5 &&
+      movedWidget.y < 3
+    ) {
+      widget.x += cursorPosition.x
+      widget.y += cursorPosition.y
+      return true //빈 공간으로 이동함
+    }
+    return false //빈공간으로 이동 할 수 없음
+  }
+  //이동 알고리즘 들어가는 함수 [주기능]
+  const moveItem = (index: number) => {
+    if (moveItemEmpty(widgets[index]) === true) return //빈 공간일 경우
+    //if (moveItemPush(widgets[index]) === true) return//push할 수 있는 경우
+    if (moveItemSwap(widgets[index]) === true) return //swap할 수 있는 경우
+    console.log('이동불가') //불가능
   }
 
   return (

--- a/frontend/src/components/users/Grid.tsx
+++ b/frontend/src/components/users/Grid.tsx
@@ -1,4 +1,4 @@
-import { DndContext } from '@dnd-kit/core'
+import { DndContext, DragEndEvent } from '@dnd-kit/core'
 import { rectSwappingStrategy, SortableContext } from '@dnd-kit/sortable'
 import { Widget } from 'components/widgets/Widget'
 import { layoutType } from 'common'
@@ -11,12 +11,30 @@ export const Grid = ({ gridItems }: { gridItems: layoutType }) => {
     gridTemplateColumns: 'repeat(5, 1fr)',
     gridGap: 10,
   }
+  const handleDragEnd = (event: DragEndEvent) => {
+    if (event.active.id !== event.over?.id) {
+      const oldIndex = gridItems.findIndex(
+        item => item.uuid === event.active.id
+      )
+      const newIndex = gridItems.findIndex(item => item.uuid === event.over?.id)
+      moveItem(gridItems, oldIndex, newIndex)
+    }
+  }
+  const moveItem = (layout: layoutType, oldIndex: number, newIndex: number) => {
+    //layout에서 oldIndex와 newIndex를 위치만 교체
+    const tmpX = layout[oldIndex].x
+    const tmpY = layout[oldIndex].y
+    layout[oldIndex].x = layout[newIndex].x
+    layout[oldIndex].y = layout[newIndex].y
+    layout[newIndex].x = tmpX
+    layout[newIndex].y = tmpY
+  }
   // 센서, 핸들러, 정렬 함수 등 추가할 것
   return (
     <div style={tmpStyle}>
-      <DndContext>
+      <DndContext onDragEnd={handleDragEnd}>
         <SortableContext
-          items={gridItems.map(ele => ele.name)}
+          items={gridItems.map(ele => ele.uuid)}
           strategy={rectSwappingStrategy}
         >
           {gridItems.map((ele, index) => (

--- a/frontend/src/components/users/Grid.tsx
+++ b/frontend/src/components/users/Grid.tsx
@@ -1,15 +1,15 @@
-import {
-  DndContext,
-  DragEndEvent,
-  DragMoveEvent,
-  DragOverEvent,
-} from '@dnd-kit/core'
+import { DndContext, DragEndEvent, DragMoveEvent } from '@dnd-kit/core'
 import { rectSwappingStrategy, SortableContext } from '@dnd-kit/sortable'
 import { Widget } from 'components/widgets/Widget'
-import { layoutType } from 'common'
-import { createRef, LegacyRef, Ref, useState } from 'react'
+import { Widgets, WidgetType } from 'common'
+import { createRef, LegacyRef, useState } from 'react'
 
-export const Grid = ({ gridItems }: { gridItems: layoutType }) => {
+type Coordinate = {
+  x: number
+  y: number
+}
+
+export const Grid = ({ gridItems }: { gridItems: Widgets }) => {
   const [cursorPosition, setCursorPosition] = useState({ x: 0, y: 0 })
   const gridRef: LegacyRef<HTMLDivElement> = createRef()
   const tmpStyle: React.CSSProperties = {
@@ -20,6 +20,8 @@ export const Grid = ({ gridItems }: { gridItems: layoutType }) => {
     gridTemplateColumns: 'repeat(5, 1fr)',
     gridGap: 10,
   }
+  //#######이동 알고리즘 들어가는 부분 제일 중요#########
+  //교환할 수 있는 경우 moveItem, 빈 곳으로 이동하는 경우 moveItemToEmpty로 이동
   const handleDragEnd = (event: DragEndEvent) => {
     if (event.over && event.active.id !== event.over?.id) {
       const oldIndex = gridItems.findIndex(
@@ -34,7 +36,6 @@ export const Grid = ({ gridItems }: { gridItems: layoutType }) => {
         const index = gridItems.findIndex(item => item.uuid === event.active.id)
         moveItemToEmpty(gridItems, index)
       }
-      console.log(gridItems)
     }
   }
   const handleDragMove = (event: DragMoveEvent) => {
@@ -48,9 +49,7 @@ export const Grid = ({ gridItems }: { gridItems: layoutType }) => {
     //이걸 그리드 사이즈에 대한 비율로 나눠서 어느 정도 이동했는지 좌표를 구한다
     //x, y좌표를 state로 저장한다
   }
-
-  const moveItem = (layout: layoutType, oldIndex: number, newIndex: number) => {
-    //layout에서 oldIndex와 newIndex를 위치만 교체
+  const swapItem = (layout: Widgets, oldIndex: number, newIndex: number) => {
     const tmpX = layout[oldIndex].x
     const tmpY = layout[oldIndex].y
     layout[oldIndex].x = layout[newIndex].x
@@ -58,8 +57,117 @@ export const Grid = ({ gridItems }: { gridItems: layoutType }) => {
     layout[newIndex].x = tmpX
     layout[newIndex].y = tmpY
   }
-  const moveItemToEmpty = (layout: layoutType, index: number) => {
-    console.log(index)
+  //해당 위젯이 차지하고 있는 좌표 리스트를 반환
+  const makeCoordinates = (layout: Widgets, start: number, end: number) => {
+    const swapPlace: Coordinate[] = []
+    for (let i = 0; i < layout[start].h; i++) {
+      for (let j = 0; j < layout[start].w; j++) {
+        swapPlace.push({
+          x: layout[end].x + j,
+          y: layout[end].y + i,
+        })
+      }
+    }
+    return swapPlace
+  }
+
+  const pushItem = (layout: Widgets, oldIndex: number, newIndex: number) => {
+    const swapCoordinates = makeCoordinates(layout, oldIndex, newIndex)
+    layout.map((ele, index) => {
+      if (index !== oldIndex) {
+        const eleCoordinates = makeCoordinates(layout, index, index)
+        //filtered는 중복된 좌표값 좌표값만 토대로 어떤 위젯인지 찾아야함
+        //각 위젯의 좌표배열을 생성. 배열 중 filteredEle가 있는 지 찾기.
+        const filtered = eleCoordinates.map(it => {
+          return swapCoordinates.filter(swapEle => {
+            return swapEle.x === it.x && swapEle.y === it.y
+          })
+        })
+        if (filtered[0].length === 0) return
+        //filtered 위치만 알지 무슨 위젯인지는 아직 모름
+        //일단 layout을 돌면서 해당 위치를 차지하고 있는 위젯을 찾기
+        filtered[0].map(filteredEle => {
+          const overlapWidget: WidgetType | undefined = layout.find(
+            (layoutEle, index) => {
+              const tmpWidgetCoordinate = makeCoordinates(layout, index, index)
+              const includeWidget = tmpWidgetCoordinate.map(ele => {
+                return ele.x === filteredEle.x && ele.y === filteredEle.y
+              })
+              if (includeWidget.includes(true)) return layoutEle
+            }
+          )
+          if (overlapWidget === undefined) return
+          //overlapWidget까지는 잘 찾아졌음
+          console.log(overlapWidget)
+          if (tryPush(layout, overlapWidget, { x: -1, y: 0 }) === true) return
+          if (tryPush(layout, overlapWidget, { x: 1, y: 0 }) === true) return
+          if (tryPush(layout, overlapWidget, { x: 0, y: 1 }) === true) return
+          if (tryPush(layout, overlapWidget, { x: 0, y: -1 }) === true) return
+          // console.log('밀 수 없음')
+          //위젯을 찾았으면 좌, 우, 상, 하 순서로 밀기 시도. 못찾았다면 밀지 않고 종료
+          //다 실패 시 console.log(밀 수 없음)//
+        })
+        //filtered가 비어있지 않다면 이 ele는 겹치는 위젯이다
+        //겹치는 위젯은 상하좌우로 밀 수 있음.
+        //좌->우->상->하 순서로 검사해서 밀 수 있는 지 확인하고,
+        //가능하다면 밀기
+      }
+    })
+  }
+
+  const tryPush = (
+    layout: Widgets,
+    widget: WidgetType,
+    direction: Coordinate
+  ) => {
+    //layout에서 widget을 찾아서 왼쪽으로 한 칸 밀기
+    //layout 좌표들에서 왼쪽 한 칸 기준으로 비어있는지를 확인하기.
+    const widgetIndex = layout.findIndex(ele => {
+      return ele.uuid === widget.uuid
+    })
+    const widgetCoordinate = makeCoordinates(layout, widgetIndex, widgetIndex)
+    //widgetCoodinate의 좌표들에 (-1, 0)씩 연산해서 이 위치랑 eleCoodinate랑 겹치는지 확인.
+    const moveCoordinate = widgetCoordinate.map(ele => {
+      return { x: ele.x + direction.x, y: ele.y + direction.y }
+    })
+    //오버랩을 한 칸 옮긴 위치랑 비교해서 겹치면 움직이지 말고
+    const tmp = layout.map((ele, index) => {
+      const eleCoordinate = makeCoordinates(layout, index, index)
+      const isOverlap = moveCoordinate.map(moveEle => {
+        return eleCoordinate.map(eleEle => {
+          if (moveEle.x === eleEle.x && moveEle.y === eleEle.y) return false
+          else if (moveEle.x < 0 || moveEle.y) return false
+          else return true
+        })
+      })
+      if (isOverlap[0].includes(false)) return false
+      else {
+        return true
+      }
+    })
+    if (tmp.includes(true)) {
+      //옮길 수 있음
+      widget.x += direction.x
+      widget.y += direction.y
+      return true
+    } else return false
+  }
+
+  const moveItem = (layout: Widgets, oldIndex: number, newIndex: number) => {
+    //push를 먼저 시도하고 실패하면 swap을 시도할 예정 아직 덜만듦
+
+    //1. 해당 위젯 스왑될 위치를 다음과 같은 배열로 만듬 [{x, y}, ...] 차지하고 있는 좌표들의 배열
+    //2. 위젯리스트를 돌면서 그 위젯에 대한 배열을 만들고, 1의 배열과 비교해서 겹치는 좌표가 있는 지 확인
+    //3. 겹치는 좌표가 없다면 바로 스왑
+    //4. 겹치는 좌표가 있다면, 그 위젯을 상하좌우로 밀어내기(밀어낼 위치를 검사해 가능 불가능 확인 후 밀기)
+    //5. 우선순위는 밀어내기 -> 스왑 -> 불가능
+    //드래그 시 CSS 등 세세한 동작은 추후 만들기..
+
+    pushItem(layout, oldIndex, newIndex)
+    // swapItem(layout, oldIndex, newIndex)
+  }
+
+  const moveItemToEmpty = (layout: Widgets, index: number) => {
     layout[index].x += cursorPosition.x
     layout[index].y += cursorPosition.y
   }

--- a/frontend/src/components/users/Grid.tsx
+++ b/frontend/src/components/users/Grid.tsx
@@ -1,25 +1,54 @@
-import { DndContext, DragEndEvent } from '@dnd-kit/core'
+import {
+  DndContext,
+  DragEndEvent,
+  DragMoveEvent,
+  DragOverEvent,
+} from '@dnd-kit/core'
 import { rectSwappingStrategy, SortableContext } from '@dnd-kit/sortable'
 import { Widget } from 'components/widgets/Widget'
 import { layoutType } from 'common'
+import { createRef, LegacyRef, Ref, useState } from 'react'
 
 export const Grid = ({ gridItems }: { gridItems: layoutType }) => {
+  const [cursorPosition, setCursorPosition] = useState({ x: 0, y: 0 })
+  const gridRef: LegacyRef<HTMLDivElement> = createRef()
   const tmpStyle: React.CSSProperties = {
     background: '#aaffaa',
     display: 'inline-grid',
     width: '100%',
+    height: '80vh',
     gridTemplateColumns: 'repeat(5, 1fr)',
     gridGap: 10,
   }
   const handleDragEnd = (event: DragEndEvent) => {
-    if (event.active.id !== event.over?.id) {
+    if (event.over && event.active.id !== event.over?.id) {
       const oldIndex = gridItems.findIndex(
         item => item.uuid === event.active.id
       )
       const newIndex = gridItems.findIndex(item => item.uuid === event.over?.id)
       moveItem(gridItems, oldIndex, newIndex)
+    } else if (event.active && event.over === null) {
+      //useState로 좌표를 가지고 있기 handleDragMove를 만들고 그 함수에서 계속 State를 갱신하게 하자
+      //그리고 moveItemToEmpty 같은 거 만들고 그 state를 적용시키도록 한다
+      if (cursorPosition.x !== 0 || cursorPosition.y !== 0) {
+        const index = gridItems.findIndex(item => item.uuid === event.active.id)
+        moveItemToEmpty(gridItems, index)
+      }
+      console.log(gridItems)
     }
   }
+  const handleDragMove = (event: DragMoveEvent) => {
+    if (gridRef.current) {
+      setCursorPosition({
+        x: Math.round(event.delta.x / (gridRef.current.offsetWidth / 5)),
+        y: Math.round(event.delta.y / (gridRef.current.offsetHeight / 3)),
+      })
+    }
+    //delta값에 얼마나 움직였는지 정보가 담겨있고
+    //이걸 그리드 사이즈에 대한 비율로 나눠서 어느 정도 이동했는지 좌표를 구한다
+    //x, y좌표를 state로 저장한다
+  }
+
   const moveItem = (layout: layoutType, oldIndex: number, newIndex: number) => {
     //layout에서 oldIndex와 newIndex를 위치만 교체
     const tmpX = layout[oldIndex].x
@@ -29,10 +58,15 @@ export const Grid = ({ gridItems }: { gridItems: layoutType }) => {
     layout[newIndex].x = tmpX
     layout[newIndex].y = tmpY
   }
-  // 센서, 핸들러, 정렬 함수 등 추가할 것
+  const moveItemToEmpty = (layout: layoutType, index: number) => {
+    console.log(index)
+    layout[index].x += cursorPosition.x
+    layout[index].y += cursorPosition.y
+  }
+
   return (
-    <div style={tmpStyle}>
-      <DndContext onDragEnd={handleDragEnd}>
+    <div style={tmpStyle} ref={gridRef}>
+      <DndContext onDragEnd={handleDragEnd} onDragMove={handleDragMove}>
         <SortableContext
           items={gridItems.map(ele => ele.uuid)}
           strategy={rectSwappingStrategy}

--- a/frontend/src/components/users/Users.tsx
+++ b/frontend/src/components/users/Users.tsx
@@ -8,7 +8,7 @@ export const Users = () => {
     <div>
       <Navigation />
       <Store />
-      <Grid gridItems={layoutDummy} />
+      <Grid widgets={layoutDummy} />
     </div>
   )
 }

--- a/frontend/src/components/users/users.stories.tsx
+++ b/frontend/src/components/users/users.stories.tsx
@@ -1,5 +1,5 @@
 import { Button, Navbar } from '@mantine/core'
-import { layoutType } from 'common'
+import { Widgets } from 'common'
 import { Grid } from './Grid'
 import { Navigation as tmp } from './Navigation'
 import type { Story } from '@ladle/react'
@@ -17,7 +17,7 @@ const tmpStyle: React.CSSProperties = {
 
 export const Navigation = tmp
 
-export const grid: Story<{ widgets: layoutType }> = ({ widgets }) => (
+export const grid: Story<{ widgets: Widgets }> = ({ widgets }) => (
   <Grid gridItems={widgets} />
 )
 grid.args = { widgets: layoutDummy }

--- a/frontend/src/components/widgets/Weather.tsx
+++ b/frontend/src/components/widgets/Weather.tsx
@@ -1,5 +1,5 @@
-import { widgetType } from 'common'
+import { WidgetType } from 'common'
 
-export const Weather = ({ widgetData }: { widgetData: widgetType }) => {
+export const Weather = ({ widgetData }: { widgetData: WidgetType }) => {
   return <div>{widgetData.name}</div>
 }

--- a/frontend/src/components/widgets/Widget.tsx
+++ b/frontend/src/components/widgets/Widget.tsx
@@ -13,7 +13,7 @@ export const Widget = ({
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id: widget.uuid })
   const style = {
-    transform: CSS.Transform.toString(transform), //이동 모션과 관련된 부분
+    // transform: CSS.Transform.toString(transform), //이동 모션과 관련된 부분
     // transition, //전환 동작과 관련된 부분 https://docs.dndkit.com/presets/sortable/usesortable#transition-1
     gridColumn: `${widget.x + 1 + '/' + (widget.w + widget.x + 1)}`,
     gridRow: `${widget.y + 1 + '/' + (widget.h + widget.y + 1)}`,

--- a/frontend/src/components/widgets/Widget.tsx
+++ b/frontend/src/components/widgets/Widget.tsx
@@ -1,19 +1,19 @@
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { layoutType, widgetType } from 'common'
+import { Widgets, WidgetType } from 'common'
 import { Weather } from './Weather'
 
 export const Widget = ({
   layout,
   widget,
 }: {
-  layout: layoutType
-  widget: widgetType
+  layout: Widgets
+  widget: WidgetType
 }) => {
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id: widget.uuid })
   const style = {
-    transform: CSS.Transform.toString(transform),
+    transform: CSS.Transform.toString(transform), //이동 모션과 관련된 부분
     // transition, //전환 동작과 관련된 부분 https://docs.dndkit.com/presets/sortable/usesortable#transition-1
     gridColumn: `${widget.x + 1 + '/' + (widget.w + widget.x + 1)}`,
     gridRow: `${widget.y + 1 + '/' + (widget.h + widget.y + 1)}`,

--- a/frontend/src/components/widgets/Widget.tsx
+++ b/frontend/src/components/widgets/Widget.tsx
@@ -11,17 +11,19 @@ export const Widget = ({
   widget: widgetType
 }) => {
   const { attributes, listeners, setNodeRef, transform, transition } =
-    useSortable({ id: widget.name })
+    useSortable({ id: widget.uuid })
   const style = {
     transform: CSS.Transform.toString(transform),
-    transition,
+    // transition, //전환 동작과 관련된 부분 https://docs.dndkit.com/presets/sortable/usesortable#transition-1
+    gridColumn: `${widget.x + 1 + '/' + (widget.w + widget.x + 1)}`,
+    gridRow: `${widget.y + 1 + '/' + (widget.h + widget.y + 1)}`,
   }
   const selectWidget = () => {
     switch (widget.name) {
       case 'weather':
         return <Weather widgetData={widget}></Weather>
       default:
-        return <div>dummy</div> //추후 위젯 추가
+        return <div>{widget.name}</div> //추후 위젯 추가
     }
   }
   return (

--- a/frontend/src/components/widgets/Widget.tsx
+++ b/frontend/src/components/widgets/Widget.tsx
@@ -17,6 +17,7 @@ export const Widget = ({
     // transition, //전환 동작과 관련된 부분 https://docs.dndkit.com/presets/sortable/usesortable#transition-1
     gridColumn: `${widget.x + 1 + '/' + (widget.w + widget.x + 1)}`,
     gridRow: `${widget.y + 1 + '/' + (widget.h + widget.y + 1)}`,
+    border: 'solid 1px black',
   }
   const selectWidget = () => {
     switch (widget.name) {

--- a/frontend/src/components/widgets/widgets.stories.tsx
+++ b/frontend/src/components/widgets/widgets.stories.tsx
@@ -1,15 +1,15 @@
-import { layoutType, widgetType } from 'common'
+import { Widgets, WidgetType } from 'common'
 import { Weather } from './Weather'
 import { Widget } from './Widget'
 import type { Story } from '@ladle/react'
 import { layoutDummy, widgetDummy } from 'Dummy'
 
-export const weather: Story<{ widget: widgetType }> = ({ widget }) => (
+export const weather: Story<{ widget: WidgetType }> = ({ widget }) => (
   <Weather widgetData={widget} />
 )
 weather.args = { widget: widgetDummy }
 
-export const widget: Story<{ layout: layoutType; widget: widgetType }> = ({
+export const widget: Story<{ layout: Widgets; widget: WidgetType }> = ({
   layout,
   widget,
 }) => <Widget layout={layout} widget={widget} />


### PR DESCRIPTION
#### 연결된 이슈
[그리드 배치 알고리즘 구현](https://usanglee.notion.site/8704f26742274248810e52f2d7fbecea)
## Pull Request 설명
![화면-기록-2022-11-18-오후-5 22 18](https://user-images.githubusercontent.com/72776427/202655877-a6185b4e-4ae3-475c-bc6f-3a831dce7cf1.gif)

- 위젯을 빈 공간으로 이동 할 수 있습니다
- 위젯을 자신과 같은 크기의 위젯과 서로 위치를 바꿀 수 있습니다
- 불가능한 이동을 막았습니다(그리드 바깥 크기로 나가거나 위젯이 서로 겹쳐짐)
- dnd kit에서 구현된 이동 관련 css 효과는 테스트에 방해되서 일단 없앴습니다

## Test 방법
pnpm run dev